### PR TITLE
Can't access MessageBusMixin methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-catalyst",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main" : "src/Catalyst.js",
   "repository": {
     "type": "git",

--- a/src/Catalyst.js
+++ b/src/Catalyst.js
@@ -1,2 +1,2 @@
-
 exports.LinkedStateMixin = require('./catalyst/LinkedStateMixin');
+exports.MessageBusMixin = require('./catalyst/MessageBusMixin');


### PR DESCRIPTION
Howdy! 

I followed the instructions for using the `MessageBusMixin` but I noticed that it wasn't binding the methods to my component. In this PR I'm simply exporting it into the root include so that the methods are available when I include the package. Also bumped the version for publishing to npm.
